### PR TITLE
Fix typo in XHP Bootstrap url

### DIFF
--- a/guides/hack/24-XHP/08-further-resources.md
+++ b/guides/hack/24-XHP/08-further-resources.md
@@ -1,6 +1,6 @@
 Besides our documentation, there are some other very useful resources to enhance your experience with XHP.
 
 * [XHP Library](https://github.com/facebook/xhp-lib): The class libraries for XHP.
-* [XHP Bootstrap Library](http://github.com/hhvm/xhp-boostrap): A framework providing XHP components for web pages.
+* [XHP Bootstrap Library](http://github.com/hhvm/xhp-bootstrap): A framework providing XHP components for web pages.
 * [Using XHP with Bootstrap](http://hhvm.com/blog/6515/using-xhp-with-bootstrap): A blog post about using XHP with the bootstrap library.
 * [XHP Announcement](https://www.facebook.com/notes/facebook-engineering/xhp-a-new-way-to-write-php/294003943919): The original XHP announcement from 2010.


### PR DESCRIPTION
This was `boostrap` instead of `bootstrap`, working link is http://github.com/hhvm/xhp-bootstrap